### PR TITLE
Add GitHub Action to build & push container on master push

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -1,0 +1,24 @@
+name: Publish Docker image
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: andrewjkerr/bug-bounty-in-a-box:latest


### PR DESCRIPTION
Does as it says on the tin!

Used https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-docker-hub as a guide 😄 